### PR TITLE
Add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.2",
   "title": "plainOverlay",
   "description": "The simple jQuery Plugin for customizable overlay which covers a page, elements or iframe-windows that is specified.",
+  "main": "jquery.plainoverlay.js",
   "keywords": [
     "jquery-plugin",
     "ecosystem:jquery",


### PR DESCRIPTION
Necessary in order to do `require('jquery-plainoverlay')` with CommonJS.
